### PR TITLE
fix: trunc blogful_<table> should be thingful_<table> 

### DIFF
--- a/seeds/trunc.thingful_tables.sql
+++ b/seeds/trunc.thingful_tables.sql
@@ -1,5 +1,5 @@
 TRUNCATE
-  blogful_comments,
-  blogful_articles,
-  blogful_users
+  thingful_reviews,
+  thingful_things,
+  thingful_users
   RESTART IDENTITY CASCADE;


### PR DESCRIPTION
The truncate file contain 

```
TRUNCATE
  blogful_comments,
  blogful_articles,
  blogful_users
  RESTART IDENTITY CASCADE;
```

it should point to thingful tables

```
TRUNCATE
  thingful_reviews,
  thingful_things,
  thingful_users
  RESTART IDENTITY CASCADE;
```